### PR TITLE
fixed calling real gettimeofday

### DIFF
--- a/datefudge.c
+++ b/datefudge.c
@@ -150,7 +150,7 @@ time_t real_gettimeofday(struct timeval *x, void *y) {
     static int (*libc_gettimeofday)(struct timeval *, void *) = NULL;
 
     if(!libc_gettimeofday)
-        libc_gettimeofday = (typeof(libc_gettimeofday))dlsym (RTLD_NEXT, "__gettimeofday");
+        libc_gettimeofday = (typeof(libc_gettimeofday))dlsym (RTLD_NEXT, "gettimeofday");
     return libc_gettimeofday(x, y);
 }
 


### PR DESCRIPTION
Source utility has a bug (traced it to initial commit, it's there also) with calling libc `gettimeofday`.

It attempts to call `__gettimeofday` from libc which does not exist - as original function should be searched without underscores.

Apparently it was never spotted as I haven't found an easy way to test it - `gettimeofday` is just never used. However, it is used by (at least)`date` utility in [Alpine](https://alpinelinux.org/) which is used nowadays pretty often for authoring docker images.

So an easiest test I could find is to try and build following docker image (`docker build -t datefudge-alpine-test .`):

```Dockerfile
FROM alpine:3.12

RUN apk add alpine-sdk
RUN apk add dpkg-dev

WORKDIR /home/build
COPY . ./.

RUN make

RUN echo "2020-10-22 12:13:14" > time

ENV LD_PRELOAD=/home/build/datefudge.so
ENV DATEFUDGE_FILE=/home/build/time
ENV DATEFUDGE_FILE_CACHE_MS=100

RUN date
```

Expected result is build being successfully completed, and "2020-10-22 12:13:14" to be output to the console.
Actual result is build not completing, as `date` exists with code 139, while trying to dereference a null pointer.